### PR TITLE
Gas Optimization Registry.sol

### DIFF
--- a/Registry.sol
+++ b/Registry.sol
@@ -1,83 +1,137 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.1; 
+pragma solidity ^0.8.1;
 
 interface ERC20 {
-    function balanceOf(address _tokenOwner) external view returns (uint balance);
-    function transfer(address _to, uint _tokens) external returns (bool success);
-    function approve(address _spender, uint256 _value) external returns (bool success);
-    function allowance(address _contract, address _spender) external view returns (uint256 remaining);
-    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+    function balanceOf(address _tokenOwner)
+        external
+        view
+        returns (uint balance);
+
+    function transfer(address _to, uint _tokens)
+        external
+        returns (bool success);
+
+    function approve(address _spender, uint256 _value)
+        external
+        returns (bool success);
+
+    function allowance(address _contract, address _spender)
+        external
+        view
+        returns (uint256 remaining);
+
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    ) external returns (bool success);
 }
 
 contract IDrissMappings {
-    uint public countAdding = 0; 
-    uint public countDeleting = 0; 
-    uint public price = 0;      
+    uint public countAdding = 0;
+    uint public countDeleting = 0;
+    uint public price = 0;
     uint public creationTime = block.timestamp;
-    address public contractOwner = msg.sender; 
+    address public contractOwner = msg.sender;
     mapping(string => string) private IDriss;
     mapping(string => string) private IDrissHash;
-    mapping(string => address) public IDrissOwners; 
-    mapping(string => uint) public payDates;    
+    mapping(string => address) public IDrissOwners;
+    mapping(string => uint) public payDates;
     mapping(address => bool) private admins;
-    
+
     event Increment(uint value);
     event Decrement(uint value);
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-    event IDrissOwnershipTransferred(address indexed previousIDrissOwner, address indexed newIDrissOwner);
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+    event IDrissOwnershipTransferred(
+        address indexed previousIDrissOwner,
+        address indexed newIDrissOwner
+    );
     event IDrissAdded(string indexed hash);
     event IDrissDeleted(string indexed hash);
     event NewPrice(uint price);
     event AdminAdded(address indexed admin);
     event AdminDeleted(address indexed admin);
 
-
+    error IDrissMappings__OnlyContractOwnerCanAddAdmins();
+    error IDrissMappings__OnlyContractOwnerCanDeleteAdmins();
+    error IDrissMappings__OnlyContractOwnerCanSetPrice();
+    error IDrissMappings__OnlyTrustedAdminCanWithdraw();
+    error IDrissMappings__OnlyTrustedAdminCanAddIDriss();
+    error IDrissMappings__OnlyIDrissOwnerCanDeleteBinding();
+    error IDrissMappings__OnlyIDrissOwnerCanChangeOwnership();
+    error IDrissMappings__OnlyContractOwnerCanChangeOwnership();
+    error IDrissMappings__Ownable_NewContractOwnerIsTheZeroAddress();
 
     function addAdmin(address adminAddress) external {
-        require(msg.sender == contractOwner, "Only contractOwner can add admins.");
+        if (msg.sender != contractOwner) {
+            revert IDrissMappings__OnlyContractOwnerCanAddAdmins();
+        }
         admins[adminAddress] = true;
         emit AdminAdded(adminAddress);
     }
 
     function deleteAdmin(address adminAddress) external {
-        require(msg.sender == contractOwner, "Only contractOwner can delete admins.");
+        if (msg.sender != contractOwner) {
+            revert IDrissMappings__OnlyContractOwnerCanDeleteAdmins();
+        }
         admins[adminAddress] = false;
         emit AdminDeleted(adminAddress);
     }
 
     function setPrice(uint newPrice) external {
-        require(msg.sender == contractOwner, "Only contractOwner can set price.");
+        if (msg.sender != contractOwner) {
+            revert IDrissMappings__OnlyContractOwnerCanSetPrice();
+        }
         price = newPrice;
         emit NewPrice(price);
     }
-    
+
     function withdraw() external returns (bytes memory) {
-        require(admins[msg.sender] == true, "Only trusted admin can withdraw.");
-        (bool sent, bytes memory data) = msg.sender.call{value: address(this).balance, gas: 40000}("");
+        if (admins[msg.sender] != true) {
+            revert IDrissMappings__OnlyTrustedAdminCanWithdraw();
+        }
+        (bool sent, bytes memory data) = msg.sender.call{
+            value: address(this).balance,
+            gas: 40000
+        }("");
         require(sent, "Failed to  withdraw.");
         return data;
     }
 
     function withdrawTokens(address tokenContract) external {
-        require(admins[msg.sender] == true, "Only trusted admin can withdraw.");
+        if (admins[msg.sender] != true) {
+            revert IDrissMappings__OnlyTrustedAdminCanWithdraw();
+        }
         ERC20 tc = ERC20(tokenContract);
         tc.transfer(msg.sender, tc.balanceOf(address(this)));
     }
-    
 
     function increment() private {
         countAdding += 1;
         emit Increment(countAdding);
     }
-    
+
     function decrement() private {
         countDeleting += 1;
         emit Decrement(countDeleting);
     }
 
-    function addIDriss(string memory hashPub, string memory hashID, string memory address_, address ownerAddress) external payable {
-        require(admins[msg.sender] == true, "Only trusted admin can add IDriss.");
-        require(keccak256(bytes(IDrissHash[hashPub])) == keccak256(bytes("")), "Cannot change existing binding.");
+    function addIDriss(
+        string memory hashPub,
+        string memory hashID,
+        string memory address_,
+        address ownerAddress
+    ) external payable {
+        if (admins[msg.sender] != true) {
+            revert IDrissMappings__OnlyTrustedAdminCanAddIDriss();
+        }
+        require(
+            keccak256(bytes(IDrissHash[hashPub])) == keccak256(bytes("")),
+            "Cannot change existing binding."
+        );
         require(msg.value >= price, "Not enough MATIC.");
         IDriss[hashID] = address_;
         IDrissHash[hashPub] = hashID;
@@ -86,13 +140,31 @@ contract IDrissMappings {
         increment();
         emit IDrissAdded(hashPub);
     }
-    
-    function addIDrissToken(string memory hashPub, string memory hashID, string memory address_, address token, uint amount, address ownerAddress) external payable{
-        require(admins[msg.sender] == true, "Only trusted admin can add IDriss.");
-        require(keccak256(bytes(IDrissHash[hashPub])) == keccak256(bytes("")), "Binding already created.");
+
+    function addIDrissToken(
+        string memory hashPub,
+        string memory hashID,
+        string memory address_,
+        address token,
+        uint amount,
+        address ownerAddress
+    ) external payable {
+        if (admins[msg.sender] != true) {
+            revert IDrissMappings__OnlyTrustedAdminCanAddIDriss();
+        }
+        require(
+            keccak256(bytes(IDrissHash[hashPub])) == keccak256(bytes("")),
+            "Binding already created."
+        );
         ERC20 paymentTc = ERC20(token);
-        require(paymentTc.allowance(msg.sender, address(this)) >= amount,"Insuficient Allowance.");
-        require(paymentTc.transferFrom(msg.sender, address(this), amount),"Transfer Failed.");
+        require(
+            paymentTc.allowance(msg.sender, address(this)) >= amount,
+            "Insuficient Allowance."
+        );
+        require(
+            paymentTc.transferFrom(msg.sender, address(this), amount),
+            "Transfer Failed."
+        );
         IDriss[hashID] = address_;
         IDrissHash[hashPub] = hashID;
         IDrissOwners[hashPub] = ownerAddress;
@@ -100,10 +172,15 @@ contract IDrissMappings {
         increment();
         emit IDrissAdded(hashPub);
     }
-    
+
     function deleteIDriss(string memory hashPub) external payable {
-        require(IDrissOwners[hashPub] == msg.sender, "Only IDrissOwner can delete binding.");
-        require(keccak256(bytes(IDrissHash[hashPub])) != keccak256(bytes("")), "Binding does not exist.");
+        if (IDrissOwners[hashPub] != msg.sender) {
+            revert IDrissMappings__OnlyIDrissOwnerCanDeleteBinding();
+        }
+        require(
+            keccak256(bytes(IDrissHash[hashPub])) != keccak256(bytes("")),
+            "Binding does not exist."
+        );
         delete IDriss[IDrissHash[hashPub]];
         delete IDrissHash[hashPub];
         delete IDrissOwners[hashPub];
@@ -112,20 +189,36 @@ contract IDrissMappings {
         emit IDrissDeleted(hashPub);
     }
 
-    function getIDriss(string memory hashPub) public view returns (string memory){
-        require(keccak256(bytes(IDrissHash[hashPub])) != keccak256(bytes("")), "Binding does not exist.");
+    function getIDriss(string memory hashPub)
+        public
+        view
+        returns (string memory)
+    {
+        require(
+            keccak256(bytes(IDrissHash[hashPub])) != keccak256(bytes("")),
+            "Binding does not exist."
+        );
         return IDriss[IDrissHash[hashPub]];
     }
 
-    function transferIDrissOwnership(string memory hashPub, address newOwner) external payable {
-        require(IDrissOwners[hashPub] == msg.sender, "Only IDrissOwner can change ownership.");
+    function transferIDrissOwnership(string memory hashPub, address newOwner)
+        external
+        payable
+    {
+        if (IDrissOwners[hashPub] != msg.sender) {
+            revert IDrissMappings__OnlyIDrissOwnerCanChangeOwnership();
+        }
         IDrissOwners[hashPub] = newOwner;
         emit IDrissOwnershipTransferred(msg.sender, newOwner);
     }
 
     function transferContractOwnership(address newOwner) public payable {
-        require(msg.sender == contractOwner, "Only contractOwner can change ownership of contract.");
-        require(newOwner != address(0), "Ownable: new contractOwner is the zero address.");
+        if (msg.sender != contractOwner) {
+            revert IDrissMappings__OnlyContractOwnerCanChangeOwnership();
+        }
+        if (newOwner == address(0)) {
+            revert IDrissMappings__Ownable_NewContractOwnerIsTheZeroAddress();
+        }
         _transferOwnership(newOwner);
     }
 


### PR DESCRIPTION
Just like tipping.sol, Registry.sol also had many `require` statements. It was making it too much gas costly. As error messages were storing a full length of strings. So I just replace those require statements with the `custom errors`. Now the contract is more gas optimized (Alhumduilah)

It's saving **400000+ Gas** deployment cost.

Before Gas Optimization:
![IDrissOneBefore](https://user-images.githubusercontent.com/99166851/184515204-1f9ec7c0-a65d-465a-be59-125e797cd287.JPG)

After Gas Optimization:
![IDrissOneAfter2](https://user-images.githubusercontent.com/99166851/185642449-7247a022-465f-4b29-a0b5-0cdc6550ad53.JPG)

Check this post out for more [info](https://ethereum.stackexchange.com/questions/101782/requirecondition-message-vs-revert-with-a-custom-error-which-is-better-a)

Thanks.
AB Dee