### PR TITLE
Pragma Fixed

### DIFF
--- a/src/contracts/Registry.sol
+++ b/src/contracts/Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.1;
+pragma solidity 0.8.7;
 
 interface ERC20 {
     function balanceOf(address _tokenOwner)

--- a/src/contracts/SendToHash.sol
+++ b/src/contracts/SendToHash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/src/contracts/enums/IDrissEnums.sol
+++ b/src/contracts/enums/IDrissEnums.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 enum AssetType {
     Coin,

--- a/src/contracts/interfaces/IIDrissRegistry.sol
+++ b/src/contracts/interfaces/IIDrissRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 interface IIDrissRegistry {
     function getIDriss(string memory hashPub) external view returns (string memory);

--- a/src/contracts/interfaces/ISendToHash.sol
+++ b/src/contracts/interfaces/ISendToHash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { AssetType } from "../enums/IDrissEnums.sol";
 

--- a/src/contracts/libs/ConversionUtils.sol
+++ b/src/contracts/libs/ConversionUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 //TODO: add documentation
 library ConversionUtils {

--- a/src/contracts/mocks/IDrissRegistryMock.sol
+++ b/src/contracts/mocks/IDrissRegistryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/src/contracts/mocks/MaticPriceAggregatorV3Mock.sol
+++ b/src/contracts/mocks/MaticPriceAggregatorV3Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 /**
  * @title MaticPriceAggregatorV3Mock

--- a/src/contracts/mocks/SendToHashMock.sol
+++ b/src/contracts/mocks/SendToHashMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { ISendToHash } from "../interfaces/ISendToHash.sol";
 import { SendToHash } from "../SendToHash.sol"; 

--- a/src/contracts/mocks/SendToHashMockData.sol
+++ b/src/contracts/mocks/SendToHashMockData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { ISendToHash } from "../interfaces/ISendToHash.sol";
 import { SendToHash } from "../SendToHash.sol"; 

--- a/src/contracts/mocks/SendToHashReentrancyMock.sol
+++ b/src/contracts/mocks/SendToHashReentrancyMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { ISendToHash } from "../interfaces/ISendToHash.sol";
 import { AssetType } from "../enums/IDrissEnums.sol";

--- a/src/contracts/mocks/SendToHashUtilsMock.sol
+++ b/src/contracts/mocks/SendToHashUtilsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { SendToHash } from "../SendToHash.sol";
 import { ConversionUtils } from "../libs/ConversionUtils.sol";

--- a/src/contracts/payment.sol
+++ b/src/contracts/payment.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.1; 
+pragma solidity 0.8.7; 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 contract payments {

--- a/src/contracts/reverseMapping.sol
+++ b/src/contracts/reverseMapping.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.1;
+pragma solidity 0.8.7;
 
 interface IDriss {
     function getIDriss(string memory hashPub) external view returns (string memory);

--- a/src/contracts/structs/IDrissStructs.sol
+++ b/src/contracts/structs/IDrissStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 struct AssetLiability {
     uint256 amount;

--- a/src/contracts/tipping.sol
+++ b/src/contracts/tipping.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity 0.8.7;
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 


### PR DESCRIPTION
**Floating pragmas are considered a bad practice.**

It is always recommended that `pragma` should be fixed (not floating) to the version that you are intending to deploy your contracts with. 
I have fixed the pragma of the contracts to `0.8.7` as in the hardhat.config.ts solidity compiler version is `0.8.7` is mentioned. And also some old contracts' solidity version was still set to `0.8.1`, so I fixed that as well :)


For more information Check [this](https://www.oreilly.com/library/view/mastering-blockchain-programming/9781839218262/d1250994-b952-4d5e-9cde-1b852c18b55f.xhtml) out

Thanks,
AB Dee.