### PR TITLE
Little More Gas Optimization

### DIFF
--- a/src/contracts/Registry.sol
+++ b/src/contracts/Registry.sol
@@ -28,9 +28,9 @@ interface ERC20 {
 }
 
 contract IDrissMappings {
-    uint public countAdding = 0;
-    uint public countDeleting = 0;
-    uint public price = 0;
+    uint public countAdding;
+    uint public countDeleting;
+    uint public price;
     uint public creationTime = block.timestamp;
     address public contractOwner = msg.sender;
     mapping(string => string) private IDriss;


### PR DESCRIPTION
In Solidity, If you don't define a `uint` then it defaults to `zero` automatically. But if you define it hardcoded way to its default value then it costs some extra gas. So there is no need to define these units to 0.

Before:
![before](https://user-images.githubusercontent.com/99166851/185775403-9071f1a8-32cd-4389-abce-092047429d45.JPG)

After:
![after](https://user-images.githubusercontent.com/99166851/185775417-12adce07-93f8-4b4b-a028-be09225b2349.JPG)

Thanks,
AB Dee.
